### PR TITLE
Fix/fix custom segments examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ Additionally, the library provides a generic `ZxxSegment` class that handles any
 
 ```csharp
 using ClearHl7;
+using ClearHl7.Helpers;
 using ClearHl7.V282.Types;
 
 public class ZdsSegment : ISegment
@@ -745,9 +746,9 @@ public class ZdsSegment : ISegment
 
     public void FromDelimitedString(string delimitedString, Separators separators)
     {
-        var seps = separators ?? new Separators();
-        var fields = delimitedString?.Split(seps.FieldSeparator);
-        
+        Separators seps = separators ?? new Separators().UsingConfigurationValues();
+        var fields = delimitedString?.Split(seps.FieldSeparator, StringSplitOptions.None);
+
         if (fields == null || fields.Length == 0) return;
 
         // Parse fields (skip field 0 which is the segment ID)
@@ -768,7 +769,7 @@ public class ZdsSegment : ISegment
         // Handle repeating contact info
         if (fields.Length > 4 && !string.IsNullOrEmpty(fields[4]))
         {
-            var contactElements = fields[4].Split(seps.FieldRepeatSeparator);
+            var contactElements = fields[4].Split(seps.FieldRepeatSeparator, StringSplitOptions.None);
             ContactInfo = new ExtendedTelecommunicationNumber[contactElements.Length];
             for (int i = 0; i < contactElements.Length; i++)
             {
@@ -790,30 +791,29 @@ public class ZdsSegment : ISegment
         // Handle comments with escape sequences
         if (fields.Length > 6 && !string.IsNullOrEmpty(fields[6]))
         {
-            Comments = Helpers.StringHelper.Unescape(fields[6]);
+            Comments = StringHelper.Unescape(fields[6]);
         }
     }
 
     public string ToDelimitedString()
     {
-        var seps = new Separators();
         var fields = new string[7];
-        
+
         fields[0] = Id;
         fields[1] = RecordId;
         fields[2] = DataSource?.ToDelimitedString();
         fields[3] = ProcessingStatus?.ToDelimitedString();
-        
+
         if (ContactInfo?.Length > 0)
         {
-            fields[4] = string.Join(seps.FieldRepeatSeparator.ToString(), 
+            fields[4] = string.Join(Configuration.FieldRepeatSeparator,
                 ContactInfo.Select(ci => ci?.ToDelimitedString() ?? string.Empty));
         }
-        
-        fields[5] = LastUpdated?.ToString("yyyyMMddHHmmss");
-        fields[6] = !string.IsNullOrEmpty(Comments) ? Helpers.StringHelper.Escape(Comments) : null;
 
-        return string.Join(seps.FieldSeparator.ToString(), fields);
+        fields[5] = LastUpdated?.ToString("yyyyMMddHHmmss");
+        fields[6] = !string.IsNullOrEmpty(Comments) ? StringHelper.Escape(Comments) : null;
+
+        return string.Join(Configuration.FieldSeparator, fields);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ public class ZdsSegment : ISegment
 
         // Parse fields (skip field 0 which is the segment ID)
         if (fields.Length > 1) RecordId = fields[1];
-        
+
         if (fields.Length > 2 && !string.IsNullOrEmpty(fields[2]))
         {
             DataSource = new CodedWithExceptions();
@@ -781,7 +781,7 @@ public class ZdsSegment : ISegment
         // Handle timestamp
         if (fields.Length > 5 && !string.IsNullOrEmpty(fields[5]))
         {
-            if (DateTime.TryParseExact(fields[5], "yyyyMMddHHmmss", null, 
+            if (DateTime.TryParseExact(fields[5], "yyyyMMddHHmmss", null,
                 System.Globalization.DateTimeStyles.None, out DateTime timestamp))
             {
                 LastUpdated = timestamp;
@@ -832,6 +832,76 @@ SegmentFactory.RegisterSegment<Hl7Version, ZdsSegment>("ZDS");
 
 #### 3. Use Custom Segments in Message Processing
 
+Serialization
+```csharp
+using ClearHl7;
+using ClearHl7.Serialization;
+using ClearHl7.V282.Types;
+using ClearHl7.V282;
+using ClearHl7.V282.Segments;
+using ClearHl7.Codes.V282;
+using ClearHl7.Codes.V282.Helpers;
+
+// Register for all HL7 versions (global registration)
+SegmentFactory.RegisterSegment<ZdsSegment>("ZDS");
+
+// OR register for a specific HL7 version
+SegmentFactory.RegisterSegment<Hl7Version, ZdsSegment>("ZDS");
+
+// Specify we don't want time for birth dates in PID segments
+Hl7DateTimeFormatConfig.SetPrecision<PidSegment>(x => x.DateTimeOfBirth, Consts.DateFormatPrecisionDay);
+
+// Build a new HL7 message
+var message = new Message
+{
+    Segments = new ISegment[]
+    {
+        // Add an MSH segment - Message Header
+        new MshSegment
+        {
+             SendingApplication = new HierarchicDesignator { NamespaceId = "SYSTEM" },
+             SendingFacility = new HierarchicDesignator { NamespaceId = "SENDER" },
+             ReceivingApplication = new HierarchicDesignator { NamespaceId = "RECEIVER" },
+             ReceivingFacility = new HierarchicDesignator { NamespaceId = "DEST" },
+             DateTimeOfMessage = new DateTime(2024, 1, 1, 12, 0, 0),
+             MessageType = new MessageType { MessageCode = EnumMaps.EnumToCode(CodeMessageType.AdtMessage),
+                 TriggerEvent = EnumMaps.EnumToCode(CodeEventTypeCode.AdtAckAdmitVisitNotification) },
+             MessageControlId = "MSG001",
+             ProcessingId = new ProcessingType { ProcessingId = EnumMaps.EnumToCode(CodeProcessingId.Production) },
+             VersionId = new VersionIdentifier { VersionId = EnumMaps.EnumToCode(CodeVersionId.Release282)},
+        },
+
+        // Add a PID segment - Patient Identification
+        new PidSegment
+        {
+            SetIdPid = 1,
+            PatientIdentifierList = [ new ExtendedCompositeIdWithCheckDigit { IdNumber = "12345",
+                                        IdentifierTypeCode = EnumMaps.EnumToCode(CodeIdentifierType.MedicalRecordNumber) } ],
+            PatientName = [ new ExtendedPersonName { FamilyName = new FamilyName { Surname = "Doe" }, GivenName = "John",
+                                SecondAndFurtherGivenNamesOrInitialsThereof = "J" } ],
+            DateTimeOfBirth = new DateTime(1980, 1, 1),
+            AdministrativeSex = new CodedWithExceptions { Identifier = EnumMaps.EnumToCode(CodeAdministrativeSex.Male) }
+        },
+
+        // Add a Zxx segment (custom segment -> "ZDS")
+        new ZdsSegment
+        {
+            RecordId = "REC001",
+            DataSource = new CodedWithExceptions { Identifier = "SRC", Text = "Data Source", NameOfCodingSystem = "L" },
+            ProcessingStatus = new CodedWithExceptions { Identifier = "PROC", Text = "Processing", NameOfCodingSystem = "L" },
+            ContactInfo = [ new ExtendedTelecommunicationNumber { TelephoneNumber = "555-1234",
+                            TelecommunicationUseCode = EnumMaps.EnumToCode(CodeTelecommunicationUseCode.WorkNumber),
+                            TelecommunicationEquipmentType = EnumMaps.EnumToCode(CodeTelecommunicationEquipmentType.Telephone) } ],
+            LastUpdated = new DateTime(2024, 1, 1, 12, 0, 0),
+            Comments = "Custom data segment"
+        }
+    }
+};
+
+string output = MessageSerializer.Serialize(message);
+```
+
+Deserialization
 ```csharp
 using ClearHl7;
 using ClearHl7.Serialization;

--- a/src/ClearHl7/Examples/SegmentFactoryExample.cs
+++ b/src/ClearHl7/Examples/SegmentFactoryExample.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Linq;
 using ClearHl7.Extensions;
+using ClearHl7.Helpers;
 using ClearHl7.Serialization;
-using ClearHl7.V281;
 using ClearHl7.V281.Types;
 
 namespace ClearHl7.Examples
@@ -57,22 +57,22 @@ namespace ClearHl7.Examples
         public string Comments { get; set; }
 
         /// <inheritdoc/>
-        public void FromDelimitedString(string delimitedString) 
-        { 
+        public void FromDelimitedString(string delimitedString)
+        {
             FromDelimitedString(delimitedString, null);
         }
 
         /// <inheritdoc/>
         public void FromDelimitedString(string delimitedString, Separators separators)
         {
-            var seps = separators ?? new Separators();
+            Separators seps = separators ?? new Separators().UsingConfigurationValues();
             var fields = delimitedString?.Split(seps.FieldSeparator, StringSplitOptions.None);
-            
+
             if (fields == null || fields.Length == 0)
                 return;
 
             // Skip field 0 (segment ID "ZDS")
-            
+
             // ZDS.1 - Record ID
             if (fields.Length > 1 && !string.IsNullOrEmpty(fields[1]))
             {
@@ -129,42 +129,41 @@ namespace ClearHl7.Examples
             // ZDS.7 - Comments (text with potential escape sequences)
             if (fields.Length > 7 && !string.IsNullOrEmpty(fields[7]))
             {
-                Comments = Helpers.StringHelper.Unescape(fields[7]);
+                Comments = StringHelper.Unescape(fields[7]);
             }
         }
 
         /// <inheritdoc/>
         public string ToDelimitedString()
         {
-            var seps = new Separators();
             var fields = new string[8]; // ZDS has 7 fields (index 0 is segment ID)
-            
+
             fields[0] = Id;
             fields[1] = RecordId;
             fields[2] = DataSource?.ToDelimitedString();
             fields[3] = ProcessingStatus?.ToDelimitedString();
-            
+
             // Handle repeating contact info
             if (ContactInfo?.Length > 0)
             {
-                fields[4] = string.Join(seps.FieldRepeatSeparator.ToString(), 
+                fields[4] = string.Join(Configuration.FieldRepeatSeparator,
                     ContactInfo.Select(ci => ci?.ToDelimitedString() ?? string.Empty));
             }
-            
+
             // Handle repeating data categories
             if (DataCategories?.Length > 0)
             {
-                fields[5] = string.Join(seps.FieldRepeatSeparator.ToString(), 
+                fields[5] = string.Join(Configuration.FieldRepeatSeparator,
                     DataCategories.Select(dc => dc?.ToDelimitedString() ?? string.Empty));
             }
-            
+
             // Handle timestamp
             fields[6] = LastUpdated?.ToString("yyyyMMddHHmmss");
-            
-            // Handle comments with escaping
-            fields[7] = !string.IsNullOrEmpty(Comments) ? Helpers.StringHelper.Escape(Comments) : null;
 
-            return string.Join(seps.FieldSeparator.ToString(), fields);
+            // Handle comments with escaping
+            fields[7] = !string.IsNullOrEmpty(Comments) ? StringHelper.Escape(Comments) : null;
+
+            return string.Join(Configuration.FieldSeparator, fields);
         }
     }
 
@@ -196,8 +195,8 @@ namespace ClearHl7.Examples
         public DateTime? EffectiveDate { get; set; }
 
         /// <inheritdoc/>
-        public void FromDelimitedString(string delimitedString) 
-        { 
+        public void FromDelimitedString(string delimitedString)
+        {
             FromDelimitedString(delimitedString, null);
         }
 
@@ -206,7 +205,7 @@ namespace ClearHl7.Examples
         {
             var seps = separators ?? new Separators();
             var fields = delimitedString?.Split(seps.FieldSeparator, StringSplitOptions.None);
-            
+
             if (fields == null || fields.Length == 0)
                 return;
 
@@ -267,20 +266,20 @@ namespace ClearHl7.Examples
 
             // Test comprehensive message parsing with multiple custom segments
             Console.WriteLine("\n3. Testing message parsing with complex custom segments...");
-            string complexHl7Message = 
+            string complexHl7Message =
                 "MSH|^~\\&|SYSTEM|SENDER|RECEIVER|DESTINATION|20240101120000||ADT^A01|MSG001|P|2.8.1||||\r" +
                 "PID|1||12345^^^^MR||Doe^John^J||19800101|M||2106-3|123 Main St^^Anytown^ST^12345^USA||(555)123-4567^PRN^PH|\r" +
                 "ZDS|REC001|SRC^Data Source^L|PROC^Processing^L|555-1234^WPN^PH~john@email.com^^^EMAIL|CAT1^Category1^L~CAT2^Category2^L|20240101120000|This is a comment with special chars: Test \\T\\ Data\r" +
                 "ZPD|PREF001|Vegetarian|20240101\r" +
                 "ZDS|REC002|SRC2^Another Source^L|COMP^Completed^L|||20240101130000|Second ZDS segment\r";
 
-            var message = MessageSerializer.Deserialize<Message>(complexHl7Message);
-            
+            var message = MessageSerializer.Deserialize(complexHl7Message);
+
             Console.WriteLine($"   ✓ Parsed message with {message.Segments.Count()} segments");
 
             // Test the new extension methods for accessing segments
             Console.WriteLine("\n4. Testing segment access via new extension methods...");
-            
+
             // Access specific segments by ID
             var mshSegment = message.GetSegment("MSH");
             var pidSegment = message.GetSegment("PID");
@@ -290,7 +289,7 @@ namespace ClearHl7.Examples
             // Access custom segments - multiple ZDS segments
             var zdsSegments = message.GetCustomSegments("ZDS").ToList();
             Console.WriteLine($"   ✓ Found {zdsSegments.Count} ZDS custom segments");
-            
+
             foreach (var zds in zdsSegments.Cast<ZdsSegment>())
             {
                 Console.WriteLine($"     - ZDS Record ID: {zds.RecordId}");
@@ -319,7 +318,7 @@ namespace ClearHl7.Examples
             Console.WriteLine("\n5. Testing typed segment access...");
             var typedZdsSegments = message.GetSegments<ZdsSegment>("ZDS").ToList();
             var typedZpdSegment = message.GetSegment<ZpdSegment>("ZPD");
-            
+
             Console.WriteLine($"   ✓ Found {typedZdsSegments.Count} ZDS segments via typed access");
             Console.WriteLine($"   ✓ Found ZPD segment via typed access: {typedZpdSegment?.PreferenceCode}");
 
@@ -328,7 +327,7 @@ namespace ClearHl7.Examples
             string serializedMessage = message.ToDelimitedString();
             Console.WriteLine("   ✓ Successfully serialized message back to HL7 format");
             Console.WriteLine($"   ✓ Total message length: {serializedMessage.Length} characters");
-            
+
             // Verify custom segments are preserved in serialization
             var lines = serializedMessage.Split('\r');
             var zdsLines = lines.Where(l => l.StartsWith("ZDS")).ToList();

--- a/test/ClearHl7.Tests/FactoryTests/SegmentFactoryTests.cs
+++ b/test/ClearHl7.Tests/FactoryTests/SegmentFactoryTests.cs
@@ -384,7 +384,7 @@ namespace ClearHl7.Tests.FactoryTests
 
         public void FromDelimitedString(string delimitedString, Separators separators)
         {
-            var seps = separators ?? new Separators();
+            Separators seps = separators ?? new Separators().UsingConfigurationValues();
             var fields = delimitedString?.Split(seps.FieldSeparator, StringSplitOptions.None);
             
             if (fields == null || fields.Length == 0) return;
@@ -419,13 +419,12 @@ namespace ClearHl7.Tests.FactoryTests
 
             if (fields.Length > 5 && !string.IsNullOrEmpty(fields[5]))
             {
-                Comments = Helpers.StringHelper.Unescape(fields[5]);
+                Comments = StringHelper.Unescape(fields[5]);
             }
         }
 
         public string ToDelimitedString()
         {
-            var seps = new Separators();
             var fields = new string[6];
             
             fields[0] = Id;
@@ -434,14 +433,14 @@ namespace ClearHl7.Tests.FactoryTests
             
             if (ContactInfo?.Length > 0)
             {
-                fields[3] = string.Join(seps.FieldRepeatSeparator.ToString(), 
+                fields[3] = string.Join(Configuration.FieldRepeatSeparator, 
                     ContactInfo.Select(ci => ci?.ToDelimitedString() ?? string.Empty));
             }
             
             fields[4] = LastUpdated?.ToString("yyyyMMddHHmmss");
-            fields[5] = !string.IsNullOrEmpty(Comments) ? Helpers.StringHelper.Escape(Comments) : null;
+            fields[5] = !string.IsNullOrEmpty(Comments) ? StringHelper.Escape(Comments) : null;
 
-            return string.Join(seps.FieldSeparator.ToString(), fields);
+            return string.Join(Configuration.FieldSeparator, fields);
         }
     }
 

--- a/test/ClearHl7.Tests/FactoryTests/SegmentFactoryTests.cs
+++ b/test/ClearHl7.Tests/FactoryTests/SegmentFactoryTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using ClearHl7.Helpers;
 using ClearHl7.Serialization;
 using ClearHl7.V281;
 using ClearHl7.V281.Types;
@@ -331,6 +332,25 @@ namespace ClearHl7.Tests.FactoryTests
             complexSegment.ContactInfo[1].TelephoneNumber.Should().Be("john@email.com");
             complexSegment.LastUpdated.Should().Be(new DateTime(2024, 1, 1, 12, 0, 0));
             complexSegment.Comments.Should().Be("This is a comment with special chars");
+        }
+
+
+        [Fact]
+        public void ComplexCustomSegment_WithAdvancedDataTypes_SerializeCorrectly()
+        {
+            // Arrange
+            SegmentFactory.RegisterSegment<ComplexTestSegment>("ZCX");
+
+            string hl7Message =
+                "MSH|^~\\&|SYSTEM|SENDER|RECEIVER|DEST|20240101120000||ADT^A01|MSG001|P|2.8.1\r" +
+                "ZCX|REC001|SRC^Data Source^L|555-1234^WPN^PH~john@email.com^^^EMAIL|20240101120000|This is a comment with special chars\r";
+
+            // Act
+            var message = MessageSerializer.Deserialize<Message>(hl7Message);
+            string output = MessageSerializer.Serialize(message);
+
+            // Assert
+            Assert.Equal(hl7Message, output);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes samples and examples (see issue https://github.com/davebronson/clear-hl7-net/issues/51)
Adds a unit test to verify serialization correctness : this test was missing before, thus we could not see the problem.