### PR TITLE
Optimize serialization hot paths: cache reflection in SegmentHelper a…

### DIFF
--- a/ClearHl7.sln
+++ b/ClearHl7.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearHl7.Codes", "src\Clear
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearHl7.Tests", "test\ClearHl7.Tests\ClearHl7.Tests.csproj", "{1303BCA9-187A-4CE7-A77E-51FCEC3781E4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearHl7.Benchmarks", "benchmarks\ClearHl7.Benchmarks\ClearHl7.Benchmarks.csproj", "{C7A8F3D2-9E12-4B56-8A3C-1D2E4F5A6B7C}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3D5E78A5-FB81-4AA1-8CF7-4BE3B0E7F4C9}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
@@ -30,6 +32,10 @@ Global
 		{1303BCA9-187A-4CE7-A77E-51FCEC3781E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1303BCA9-187A-4CE7-A77E-51FCEC3781E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1303BCA9-187A-4CE7-A77E-51FCEC3781E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7A8F3D2-9E12-4B56-8A3C-1D2E4F5A6B7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7A8F3D2-9E12-4B56-8A3C-1D2E4F5A6B7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7A8F3D2-9E12-4B56-8A3C-1D2E4F5A6B7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7A8F3D2-9E12-4B56-8A3C-1D2E4F5A6B7C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		Policies = $0

--- a/benchmarks/ClearHl7.Benchmarks/BenchmarkResults.md
+++ b/benchmarks/ClearHl7.Benchmarks/BenchmarkResults.md
@@ -1,0 +1,116 @@
+# ClearHl7 Performance Benchmark Results
+
+Benchmarks measuring the two hot-path optimizations introduced in this PR:
+
+1. **`SegmentHelper.GetProperties()` caching** — eliminates repeated reflection during serialization
+2. **`Assembly.CreateInstance()` factory caching** — eliminates repeated reflection + string allocations during deserialization
+
+## Environment
+
+```
+BenchmarkDotNet v0.15.0, Linux Ubuntu 24.04.4 LTS (Noble Numbat)
+AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+.NET SDK 10.0.201
+  [Host] : .NET 10.0.5 (10.0.526.15411), X64 RyuJIT AVX2
+```
+
+## How to run
+
+```bash
+dotnet run --project benchmarks/ClearHl7.Benchmarks -c Release
+```
+
+---
+
+## How the "before" numbers were captured
+
+Rather than reverting code, each source class exposes an `internal static bool DisableCaches` flag
+(visible to this project via `InternalsVisibleTo`). The `*Uncached` benchmark classes set this flag
+before their iterations so every call pays the full original reflection cost. This produces a
+genuine apples-to-apples comparison in a single benchmark run without touching production defaults.
+
+---
+
+## Deserialization benchmarks (`Assembly.CreateInstance` factory caching)
+
+| Method | Mean | Error | StdDev | Gen0 | Gen1 | Allocated |
+|---|---:|---:|---:|---:|---:|---:|
+| Deserialize 9-segment HL7 v2.9 message *(cached — after)* | 12.520 µs | 0.2328 µs | 0.2064 µs | 1.2360 | 0.3052 | 20.22 KB |
+| Deserialize 9-segment HL7 v2.9 message *(uncached — before)* | 15.132 µs | 0.1923 µs | 0.1704 µs | 1.2817 | 0.3052 | 21.77 KB |
+| Deserialize single-segment (MSH only) *(cached — after)* | 1.784 µs | 0.0291 µs | 0.0258 µs | 0.1831 | 0.1812 | 3.00 KB |
+| Deserialize single-segment (MSH only) *(uncached — before)* | 2.138 µs | 0.0344 µs | 0.0322 µs | 0.1907 | 0.1869 | 3.17 KB |
+| Auto-detect version + deserialize 9-segment *(cached — after)* | 13.184 µs | 0.1577 µs | 0.1398 µs | 1.2360 | 0.3052 | 20.29 KB |
+| Auto-detect version + deserialize 9-segment *(uncached — before)* | 15.583 µs | 0.2103 µs | 0.1756 µs | 1.2817 | 0.3052 | 21.83 KB |
+
+**Summary:** Each 9-segment deserialization is **~21% faster** (12.5 µs vs 15.1 µs), saving 2.6 µs and 1.5 KB of allocations per message.
+
+---
+
+## Serialization benchmarks (`GetProperties()` reflection caching)
+
+| Method | Mean | Error | StdDev | Gen0 | Allocated |
+|---|---:|---:|---:|---:|---:|
+| Serialize deep message 9 segments *(cached — after)* | 114.252 µs | 0.7013 µs | 0.6217 µs | 3.0518 | 51.83 KB |
+| Serialize deep message 9 segments *(uncached — before)* | 170.378 µs | 2.8307 µs | 3.5800 µs | 2.9297 | 63.53 KB |
+| Serialize shallow message (MSH only) *(cached — after)* | 7.332 µs | 0.0344 µs | 0.0305 µs | 0.3128 | 5.18 KB |
+| Serialize shallow message (MSH only) *(uncached — before)* | 7.621 µs | 0.0403 µs | 0.0336 µs | 0.3510 | 5.81 KB |
+
+**Summary:** Deep (multi-segment) serialization is **~49% faster** (114 µs vs 170 µs), saving 56 µs and 11.7 KB of allocations per message. Shallow messages (MSH only) see a smaller gain (~4%) because there is little nested-type traversal to cache.
+
+---
+
+## Real-world impact — what this actually means in practice
+
+The numbers above are per-message. Here is how they translate to real workloads:
+
+### Serialization (deep/multi-segment messages, the common case)
+
+| Daily message volume | CPU time saved per day | Memory pressure saved per day |
+|---|---|---|
+| 1,000 messages/day | ~0.06 seconds | ~11 MB |
+| 10,000 messages/day | ~0.6 seconds | ~114 MB |
+| 100,000 messages/day | ~5.6 seconds | ~1.1 GB |
+| 1,000,000 messages/day | ~56 seconds (~1 minute) | ~11 GB |
+| 10,000,000 messages/day | ~9 minutes | ~111 GB |
+
+### Deserialization (9-segment messages)
+
+| Daily message volume | CPU time saved per day |
+|---|---|
+| 100,000 messages/day | ~0.3 seconds |
+| 1,000,000 messages/day | ~2.6 seconds |
+| 10,000,000 messages/day | ~26 seconds |
+
+### Throughput (single-threaded, steady state)
+
+| Operation | Before (uncached) | After (cached) | Extra capacity |
+|---|---|---|---|
+| Serialize 9-segment messages | ~5,900 msg/sec | ~8,750 msg/sec | **+2,850 msg/sec per thread** |
+| Deserialize 9-segment messages | ~66,000 msg/sec | ~79,900 msg/sec | **+13,800 msg/sec per thread** |
+
+### Plain-English summary
+
+- **Low-volume integrations (a few thousand messages a day):** the saving is real but small —
+  fractions of a second per day. The main benefit here is the reduction in GC allocation pressure,
+  which smooths out pause spikes rather than changing wall-clock time noticeably.
+- **Mid-volume integrations (tens of thousands of messages a day):** serialization savings reach
+  several seconds per day, and the reduced allocation load (over 100 MB/day less data for the GC
+  to collect) starts to matter for latency consistency.
+- **High-volume / streaming integrations (millions of messages a day):** this is where the gains
+  compound. At 1 million messages/day, serialization alone runs a full minute faster and pushes
+  ~11 GB less data through the GC. At 10 million messages/day the CPU time saving alone is
+  ~9 minutes and each thread can handle ~49% more serialize operations per second.
+- **Memory:** the 18% per-message allocation reduction for deep serialization is the most
+  universally felt improvement — less data for the garbage collector means shorter GC pauses
+  regardless of message rate.
+
+---
+
+## Notes
+
+- All numbers are steady-state (warm cache). The very first call per type does still pay the
+  reflection cost once; after that it is a dictionary lookup.
+- The old "415–1,455×" ratios quoted previously came from BenchmarkDotNet's `Dry` (single cold)
+  iteration, which is dominated by JIT compilation rather than cache effects and does not
+  represent typical runtime behaviour. The figures above are the honest per-message numbers.
+

--- a/benchmarks/ClearHl7.Benchmarks/ClearHl7.Benchmarks.csproj
+++ b/benchmarks/ClearHl7.Benchmarks/ClearHl7.Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ClearHl7\ClearHl7.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/ClearHl7.Benchmarks/DeserializeBenchmarks.cs
+++ b/benchmarks/ClearHl7.Benchmarks/DeserializeBenchmarks.cs
@@ -1,0 +1,105 @@
+using BenchmarkDotNet.Attributes;
+using ClearHl7;
+using ClearHl7.Serialization;
+
+namespace ClearHl7.Benchmarks
+{
+    /// <summary>
+    /// Benchmarks the <see cref="MessageSerializer.Deserialize{T}"/> hot path which previously used
+    /// <c>Assembly.CreateInstance()</c> with string-built type names on every segment.
+    /// After the fix, segment factory delegates are cached in a <c>ConcurrentDictionary</c> so
+    /// the reflection overhead is paid only once per segment type per process lifetime.
+    /// </summary>
+    [MemoryDiagnoser]
+    [SimpleJob]
+    public class DeserializeBenchmarks
+    {
+        // A realistic ADT^A01 multi-segment HL7 v2.9 message covering several segment types.
+        private const string Hl7MultiSegmentMessage =
+            "MSH|^~\\&|SendApp|SendFac|RcvApp|RcvFac|20201202144539||ADT^A01|MSG001|P|2.9\r" +
+            "EVN||20201202144539\r" +
+            "PID|1||12345^^^Hospital&UNI&ISO||Smith^John^A||19800115|M|||123 Main St^^Springfield^IL^62701^USA||555-555-1234|||M||987-65-4321\r" +
+            "PV1|1|I|2WEST^201^1^HOSPITAL||||ATTEND^Doctor^Attending|||SUR||||ADM|A0\r" +
+            "IN1|1|BCBS001|Blue Cross|PO Box 100^^Chicago^IL^60601|||||||20200101|20201231\r" +
+            "AL1|1|DA|PENICILLIN|MO|Rash\r" +
+            "DG1|1||I10^Essential hypertension^ICD-10|Essential hypertension||W\r" +
+            "GT1|1||Jones^Mary^^Mrs.||100 Oak Ave^^Springfield^IL^62702||555-234-5678||19551010|F\r" +
+            "NK1|1|Smith^Jane^B|SPO|456 Elm St^^Springfield^IL^62703|555-987-6543\r";
+
+        // A minimal single-segment message used to isolate MSH parsing overhead.
+        private const string Hl7SingleSegmentMessage =
+            "MSH|^~\\&|SendApp|SendFac|RcvApp|RcvFac|20201202144539||ADT^A01|MSG001|P|2.9\r";
+
+        [Benchmark(Description = "Deserialize 9-segment HL7 v2.9 message")]
+        public V290.Message DeserializeMultiSegment()
+        {
+            return MessageSerializer.Deserialize<V290.Message>(Hl7MultiSegmentMessage);
+        }
+
+        [Benchmark(Description = "Deserialize single-segment (MSH only) HL7 v2.9 message")]
+        public V290.Message DeserializeSingleSegment()
+        {
+            return MessageSerializer.Deserialize<V290.Message>(Hl7SingleSegmentMessage);
+        }
+
+        [Benchmark(Description = "Auto-detect version and deserialize 9-segment message")]
+        public IMessage DeserializeAutoDetect()
+        {
+            return MessageSerializer.Deserialize(Hl7MultiSegmentMessage);
+        }
+    }
+
+    /// <summary>
+    /// Same deserialization benchmarks as <see cref="DeserializeBenchmarks"/> but with the
+    /// segment factory cache disabled so each iteration pays the full uncached reflection cost.
+    /// This gives a genuine "before optimisation" baseline for comparison.
+    /// </summary>
+    [MemoryDiagnoser]
+    [SimpleJob]
+    public class DeserializeBenchmarksUncached
+    {
+        private const string Hl7MultiSegmentMessage =
+            "MSH|^~\\&|SendApp|SendFac|RcvApp|RcvFac|20201202144539||ADT^A01|MSG001|P|2.9\r" +
+            "EVN||20201202144539\r" +
+            "PID|1||12345^^^Hospital&UNI&ISO||Smith^John^A||19800115|M|||123 Main St^^Springfield^IL^62701^USA||555-555-1234|||M||987-65-4321\r" +
+            "PV1|1|I|2WEST^201^1^HOSPITAL||||ATTEND^Doctor^Attending|||SUR||||ADM|A0\r" +
+            "IN1|1|BCBS001|Blue Cross|PO Box 100^^Chicago^IL^60601|||||||20200101|20201231\r" +
+            "AL1|1|DA|PENICILLIN|MO|Rash\r" +
+            "DG1|1||I10^Essential hypertension^ICD-10|Essential hypertension||W\r" +
+            "GT1|1||Jones^Mary^^Mrs.||100 Oak Ave^^Springfield^IL^62702||555-234-5678||19551010|F\r" +
+            "NK1|1|Smith^Jane^B|SPO|456 Elm St^^Springfield^IL^62703|555-987-6543\r";
+
+        private const string Hl7SingleSegmentMessage =
+            "MSH|^~\\&|SendApp|SendFac|RcvApp|RcvFac|20201202144539||ADT^A01|MSG001|P|2.9\r";
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            MessageSerializer.DisableCaches = true;
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            MessageSerializer.DisableCaches = false;
+        }
+
+        [Benchmark(Description = "Deserialize 9-segment HL7 v2.9 message — no cache")]
+        public V290.Message DeserializeMultiSegment()
+        {
+            return MessageSerializer.Deserialize<V290.Message>(Hl7MultiSegmentMessage);
+        }
+
+        [Benchmark(Description = "Deserialize single-segment (MSH only) HL7 v2.9 message — no cache")]
+        public V290.Message DeserializeSingleSegment()
+        {
+            return MessageSerializer.Deserialize<V290.Message>(Hl7SingleSegmentMessage);
+        }
+
+        [Benchmark(Description = "Auto-detect version and deserialize 9-segment message — no cache")]
+        public IMessage DeserializeAutoDetect()
+        {
+            return MessageSerializer.Deserialize(Hl7MultiSegmentMessage);
+        }
+    }
+}

--- a/benchmarks/ClearHl7.Benchmarks/Program.cs
+++ b/benchmarks/ClearHl7.Benchmarks/Program.cs
@@ -1,0 +1,18 @@
+using BenchmarkDotNet.Running;
+
+namespace ClearHl7.Benchmarks
+{
+    /// <summary>
+    /// Entry point for ClearHl7 performance benchmarks.
+    ///
+    /// Run in Release mode:
+    ///   dotnet run --project benchmarks/ClearHl7.Benchmarks -c Release
+    /// </summary>
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
+    }
+}

--- a/benchmarks/ClearHl7.Benchmarks/SerializeBenchmarks.cs
+++ b/benchmarks/ClearHl7.Benchmarks/SerializeBenchmarks.cs
@@ -1,0 +1,113 @@
+using BenchmarkDotNet.Attributes;
+using ClearHl7;
+using ClearHl7.Helpers;
+using ClearHl7.Serialization;
+
+namespace ClearHl7.Benchmarks
+{
+    /// <summary>
+    /// Benchmarks the serialization hot path which traverses segment hierarchies via
+    /// <c>SegmentHelper.SetSubcomponentFlags</c>. Previously, every traversal called
+    /// <c>Type.GetProperties()</c> (uncached reflection) on each object in the hierarchy.
+    /// After the fix, results are stored in a <c>ConcurrentDictionary</c> so reflection
+    /// is paid only once per type per process lifetime.
+    /// </summary>
+    [MemoryDiagnoser]
+    [SimpleJob]
+    public class SerializeBenchmarks
+    {
+        // A realistic ADT^A01 multi-segment HL7 v2.9 message with nested components.
+        // PID contains PatientName and PatientAddress with nested sub-components
+        // (StreetAddress, FamilyName, AssigningAuthority) — these trigger deep
+        // subcomponent-flag traversal during serialization.
+        private const string Hl7MultiSegmentMessage =
+            "MSH|^~\\&|SendApp|SendFac|RcvApp|RcvFac|20201202144539||ADT^A01|MSG001|P|2.9\r" +
+            "EVN||20201202144539\r" +
+            "PID|1||12345^^^Hospital&UNI&ISO||Smith^John^A||19800115|M|||123 Main St&Apt 4B^^Springfield^IL^62701^USA||555-555-1234|||M||987-65-4321\r" +
+            "PV1|1|I|2WEST^201^1^HOSPITAL||||ATTEND^Doctor^Attending|||SUR||||ADM|A0\r" +
+            "IN1|1|BCBS001|Blue Cross|PO Box 100^^Chicago^IL^60601|||||||20200101|20201231\r" +
+            "AL1|1|DA|PENICILLIN|MO|Rash\r" +
+            "DG1|1||I10^Essential hypertension^ICD-10|Essential hypertension||W\r" +
+            "GT1|1||Jones^Mary^^Mrs.||100 Oak Ave^^Springfield^IL^62702||555-234-5678||19551010|F\r" +
+            "NK1|1|Smith^Jane^B|SPO|456 Elm St^^Springfield^IL^62703|555-987-6543\r";
+
+        private const string Hl7SingleSegmentMessage =
+            "MSH|^~\\&|SendApp|SendFac|RcvApp|RcvFac|20201202144539||ADT^A01|MSG001|P|2.9\r";
+
+        private V290.Message _deepMessage = null!;
+        private V290.Message _shallowMessage = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            // Deserialize once to build the object graph used for serialization benchmarks.
+            _deepMessage = MessageSerializer.Deserialize<V290.Message>(Hl7MultiSegmentMessage);
+            _shallowMessage = MessageSerializer.Deserialize<V290.Message>(Hl7SingleSegmentMessage);
+        }
+
+        [Benchmark(Description = "Serialize shallow message (MSH only)")]
+        public string SerializeShallow()
+        {
+            return MessageSerializer.Serialize(_shallowMessage);
+        }
+
+        [Benchmark(Description = "Serialize deep message (9 segments with nested types)")]
+        public string SerializeDeep()
+        {
+            return MessageSerializer.Serialize(_deepMessage);
+        }
+    }
+
+    /// <summary>
+    /// Same serialization benchmarks as <see cref="SerializeBenchmarks"/> but with the
+    /// reflection caches disabled so each iteration pays the full uncached reflection cost.
+    /// This gives a genuine "before optimisation" baseline for comparison.
+    /// </summary>
+    [MemoryDiagnoser]
+    [SimpleJob]
+    public class SerializeBenchmarksUncached
+    {
+        private const string Hl7MultiSegmentMessage =
+            "MSH|^~\\&|SendApp|SendFac|RcvApp|RcvFac|20201202144539||ADT^A01|MSG001|P|2.9\r" +
+            "EVN||20201202144539\r" +
+            "PID|1||12345^^^Hospital&UNI&ISO||Smith^John^A||19800115|M|||123 Main St&Apt 4B^^Springfield^IL^62701^USA||555-555-1234|||M||987-65-4321\r" +
+            "PV1|1|I|2WEST^201^1^HOSPITAL||||ATTEND^Doctor^Attending|||SUR||||ADM|A0\r" +
+            "IN1|1|BCBS001|Blue Cross|PO Box 100^^Chicago^IL^60601|||||||20200101|20201231\r" +
+            "AL1|1|DA|PENICILLIN|MO|Rash\r" +
+            "DG1|1||I10^Essential hypertension^ICD-10|Essential hypertension||W\r" +
+            "GT1|1||Jones^Mary^^Mrs.||100 Oak Ave^^Springfield^IL^62702||555-234-5678||19551010|F\r" +
+            "NK1|1|Smith^Jane^B|SPO|456 Elm St^^Springfield^IL^62703|555-987-6543\r";
+
+        private const string Hl7SingleSegmentMessage =
+            "MSH|^~\\&|SendApp|SendFac|RcvApp|RcvFac|20201202144539||ADT^A01|MSG001|P|2.9\r";
+
+        private V290.Message _deepMessage = null!;
+        private V290.Message _shallowMessage = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            SegmentHelper.DisableCaches = true;
+            _deepMessage = MessageSerializer.Deserialize<V290.Message>(Hl7MultiSegmentMessage);
+            _shallowMessage = MessageSerializer.Deserialize<V290.Message>(Hl7SingleSegmentMessage);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            SegmentHelper.DisableCaches = false;
+        }
+
+        [Benchmark(Description = "Serialize shallow message (MSH only) — no cache")]
+        public string SerializeShallow()
+        {
+            return MessageSerializer.Serialize(_shallowMessage);
+        }
+
+        [Benchmark(Description = "Serialize deep message (9 segments with nested types) — no cache")]
+        public string SerializeDeep()
+        {
+            return MessageSerializer.Serialize(_deepMessage);
+        }
+    }
+}

--- a/src/ClearHl7/Helpers/SegmentHelper.cs
+++ b/src/ClearHl7/Helpers/SegmentHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 
@@ -10,6 +11,15 @@ namespace ClearHl7.Helpers
     /// </summary>
     public class SegmentHelper
     {
+        private static readonly ConcurrentDictionary<Type, PropertyInfo[]> _propertiesCache = new ConcurrentDictionary<Type, PropertyInfo[]>();
+        private static readonly ConcurrentDictionary<Type, PropertyInfo> _isSubcomponentPropertyCache = new ConcurrentDictionary<Type, PropertyInfo>();
+
+        /// <summary>
+        /// When true, bypasses the reflection caches and performs raw reflection on every call.
+        /// Intended for benchmark comparison only; do not set this in production code.
+        /// </summary>
+        internal static bool DisableCaches { get; set; } = false;
+
         /// <summary>
         /// Sets the IsSubcomponent property for any HL7 objects that are nested at the subcomponent level.
         /// </summary>
@@ -38,11 +48,16 @@ namespace ClearHl7.Helpers
             }
 
             Type objectType = obj.GetType();
-            PropertyInfo[] objectProperties = objectType.GetProperties();
+            PropertyInfo[] objectProperties = DisableCaches
+                ? objectType.GetProperties()
+                : _propertiesCache.GetOrAdd(objectType, t => t.GetProperties());
 
             if (nestingLevel > 1)
             {
-                obj.GetType().GetProperty("IsSubcomponent", BindingFlags.Public | BindingFlags.Instance)?.SetValue(obj, true, null);
+                PropertyInfo isSubcomponentProperty = DisableCaches
+                    ? objectType.GetProperty("IsSubcomponent", BindingFlags.Public | BindingFlags.Instance)
+                    : _isSubcomponentPropertyCache.GetOrAdd(objectType, t => t.GetProperty("IsSubcomponent", BindingFlags.Public | BindingFlags.Instance));
+                isSubcomponentProperty?.SetValue(obj, true, null);
 
                 // At the deepest level, so no need to continue searching for deeper levels within the current object.
                 return;

--- a/src/ClearHl7/Properties/AssemblyInfo.cs
+++ b/src/ClearHl7/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// Grant the benchmark project access to internal members (e.g., DisableCaches flags used
+// to measure uncached/before-optimisation performance without reverting any source changes).
+[assembly: InternalsVisibleTo("ClearHl7.Benchmarks")]

--- a/src/ClearHl7/Serialization/MessageSerializer.cs
+++ b/src/ClearHl7/Serialization/MessageSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -12,6 +13,16 @@ namespace ClearHl7.Serialization
     /// </summary>
     public static class MessageSerializer
     {
+        // Cache for segment factory delegates keyed by fully-qualified type name.
+        // Avoids repeated reflection and string allocations on the deserialization hot path.
+        private static readonly ConcurrentDictionary<string, Func<object>> _segmentFactoryCache = new ConcurrentDictionary<string, Func<object>>();
+
+        /// <summary>
+        /// When true, bypasses the segment factory cache and performs raw reflection on every call.
+        /// Intended for benchmark comparison only; do not set this in production code.
+        /// </summary>
+        internal static bool DisableCaches { get; set; } = false;
+
         /// <summary>
         /// Parses the text representing a single Message value into an instance of the appropriate type based upon the HL7 version provided in delimitedString.
         /// </summary>
@@ -93,7 +104,8 @@ namespace ClearHl7.Serialization
             }
 
             // Process the first segment (expected: MSH)
-            ISegment mshSegment = (ISegment)messageClass.Assembly.CreateInstance($"{ messageClass.Namespace }.Segments.MshSegment", false);
+            string mshTypeName = $"{ messageClass.Namespace }.Segments.MshSegment";
+            ISegment mshSegment = (ISegment)CreateCachedSegmentInstance(messageClass.Assembly, mshTypeName);
             if (segments.Length > 0)
             {
                 list.Add(mshSegment);
@@ -132,8 +144,9 @@ namespace ClearHl7.Serialization
                 }
                 else
                 {
-                    // Fall back to reflection for built-in segments
-                    segment = messageClass.Assembly.CreateInstance($"{ messageClass.Namespace }.Segments.{ id.Substring(0, 1).ToUpper(culture) }{ id.Substring(1, 2).ToLower(culture) }Segment", false);
+                    // Fall back to reflection for built-in segments (result is cached after first lookup)
+                    string typeName = $"{ messageClass.Namespace }.Segments.{ id.Substring(0, 1).ToUpper(culture) }{ id.Substring(1, 2).ToLower(culture) }Segment";
+                    segment = CreateCachedSegmentInstance(messageClass.Assembly, typeName);
                 }
 
                 if (segment == null)
@@ -278,6 +291,32 @@ namespace ClearHl7.Serialization
             }
 
             return message.ToDelimitedString();
+        }
+
+        /// <summary>
+        /// Creates an instance of a segment type by its fully-qualified name, using a cached factory
+        /// delegate after the first call so that subsequent calls avoid reflection overhead.
+        /// </summary>
+        /// <param name="assembly">The assembly that contains the segment type.</param>
+        /// <param name="typeName">The fully-qualified type name (e.g. "ClearHl7.V290.Segments.PidSegment").</param>
+        /// <returns>A new instance of the segment type, or null if the type is not found.</returns>
+        private static object CreateCachedSegmentInstance(Assembly assembly, string typeName)
+        {
+            if (DisableCaches)
+            {
+                Type type = assembly.GetType(typeName);
+                return type != null ? Activator.CreateInstance(type) : null;
+            }
+
+            Func<object> factory = _segmentFactoryCache.GetOrAdd(typeName, tn =>
+            {
+                Type type = assembly.GetType(tn);
+                if (type == null)
+                    return null;
+                return () => Activator.CreateInstance(type);
+            });
+
+            return factory?.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
# ClearHl7 Performance Benchmark Results

Benchmarks measuring the two hot-path optimizations introduced in this PR:

1. **`SegmentHelper.GetProperties()` caching** — eliminates repeated reflection during serialization
2. **`Assembly.CreateInstance()` factory caching** — eliminates repeated reflection + string allocations during deserialization

## Environment

```
BenchmarkDotNet v0.15.0, Linux Ubuntu 24.04.4 LTS (Noble Numbat)
AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
.NET SDK 10.0.201
  [Host] : .NET 10.0.5 (10.0.526.15411), X64 RyuJIT AVX2
```

## How to run

```bash
dotnet run --project benchmarks/ClearHl7.Benchmarks -c Release
```

---

## How the "before" numbers were captured

Rather than reverting code, each source class exposes an `internal static bool DisableCaches` flag
(visible to this project via `InternalsVisibleTo`). The `*Uncached` benchmark classes set this flag
before their iterations so every call pays the full original reflection cost. This produces a
genuine apples-to-apples comparison in a single benchmark run without touching production defaults.

---

## Deserialization benchmarks (`Assembly.CreateInstance` factory caching)

| Method | Mean | Error | StdDev | Gen0 | Gen1 | Allocated |
|---|---:|---:|---:|---:|---:|---:|
| Deserialize 9-segment HL7 v2.9 message *(cached — after)* | 12.520 µs | 0.2328 µs | 0.2064 µs | 1.2360 | 0.3052 | 20.22 KB |
| Deserialize 9-segment HL7 v2.9 message *(uncached — before)* | 15.132 µs | 0.1923 µs | 0.1704 µs | 1.2817 | 0.3052 | 21.77 KB |
| Deserialize single-segment (MSH only) *(cached — after)* | 1.784 µs | 0.0291 µs | 0.0258 µs | 0.1831 | 0.1812 | 3.00 KB |
| Deserialize single-segment (MSH only) *(uncached — before)* | 2.138 µs | 0.0344 µs | 0.0322 µs | 0.1907 | 0.1869 | 3.17 KB |
| Auto-detect version + deserialize 9-segment *(cached — after)* | 13.184 µs | 0.1577 µs | 0.1398 µs | 1.2360 | 0.3052 | 20.29 KB |
| Auto-detect version + deserialize 9-segment *(uncached — before)* | 15.583 µs | 0.2103 µs | 0.1756 µs | 1.2817 | 0.3052 | 21.83 KB |

**Summary:** Each 9-segment deserialization is **~21% faster** (12.5 µs vs 15.1 µs), saving 2.6 µs and 1.5 KB of allocations per message.

---

## Serialization benchmarks (`GetProperties()` reflection caching)

| Method | Mean | Error | StdDev | Gen0 | Allocated |
|---|---:|---:|---:|---:|---:|
| Serialize deep message 9 segments *(cached — after)* | 114.252 µs | 0.7013 µs | 0.6217 µs | 3.0518 | 51.83 KB |
| Serialize deep message 9 segments *(uncached — before)* | 170.378 µs | 2.8307 µs | 3.5800 µs | 2.9297 | 63.53 KB |
| Serialize shallow message (MSH only) *(cached — after)* | 7.332 µs | 0.0344 µs | 0.0305 µs | 0.3128 | 5.18 KB |
| Serialize shallow message (MSH only) *(uncached — before)* | 7.621 µs | 0.0403 µs | 0.0336 µs | 0.3510 | 5.81 KB |

**Summary:** Deep (multi-segment) serialization is **~49% faster** (114 µs vs 170 µs), saving 56 µs and 11.7 KB of allocations per message. Shallow messages (MSH only) see a smaller gain (~4%) because there is little nested-type traversal to cache.

---

## Real-world impact — what this actually means in practice

The numbers above are per-message. Here is how they translate to real workloads:

### Serialization (deep/multi-segment messages, the common case)

| Daily message volume | CPU time saved per day | Memory pressure saved per day |
|---|---|---|
| 1,000 messages/day | ~0.06 seconds | ~11 MB |
| 10,000 messages/day | ~0.6 seconds | ~114 MB |
| 100,000 messages/day | ~5.6 seconds | ~1.1 GB |
| 1,000,000 messages/day | ~56 seconds (~1 minute) | ~11 GB |
| 10,000,000 messages/day | ~9 minutes | ~111 GB |

### Deserialization (9-segment messages)

| Daily message volume | CPU time saved per day |
|---|---|
| 100,000 messages/day | ~0.3 seconds |
| 1,000,000 messages/day | ~2.6 seconds |
| 10,000,000 messages/day | ~26 seconds |

### Throughput (single-threaded, steady state)

| Operation | Before (uncached) | After (cached) | Extra capacity |
|---|---|---|---|
| Serialize 9-segment messages | ~5,900 msg/sec | ~8,750 msg/sec | **+2,850 msg/sec per thread** |
| Deserialize 9-segment messages | ~66,000 msg/sec | ~79,900 msg/sec | **+13,800 msg/sec per thread** |

### Plain-English summary

- **Low-volume integrations (a few thousand messages a day):** the saving is real but small —
  fractions of a second per day. The main benefit here is the reduction in GC allocation pressure,
  which smooths out pause spikes rather than changing wall-clock time noticeably.
- **Mid-volume integrations (tens of thousands of messages a day):** serialization savings reach
  several seconds per day, and the reduced allocation load (over 100 MB/day less data for the GC
  to collect) starts to matter for latency consistency.
- **High-volume / streaming integrations (millions of messages a day):** this is where the gains
  compound. At 1 million messages/day, serialization alone runs a full minute faster and pushes
  ~11 GB less data through the GC. At 10 million messages/day the CPU time saving alone is
  ~9 minutes and each thread can handle ~49% more serialize operations per second.
- **Memory:** the 18% per-message allocation reduction for deep serialization is the most
  universally felt improvement — less data for the garbage collector means shorter GC pauses
  regardless of message rate.

---

## Notes

- All numbers are steady-state (warm cache). The very first call per type does still pay the
  reflection cost once; after that it is a dictionary lookup.
