### PR TITLE
Fix timezone-offset DateTime precision serialization for configured HL7 fields

### DIFF
--- a/src/ClearHl7/Extensions/StringExtensions.cs
+++ b/src/ClearHl7/Extensions/StringExtensions.cs
@@ -168,6 +168,12 @@ namespace ClearHl7.Extensions
         public static string ToHl7DateTimeString(this DateTime dateTime, Type segmentType, string propertyName, string originalFormat, CultureInfo culture)
         {
             string format = Hl7DateTimeFormatConfig.GetFormatForField(segmentType, propertyName, originalFormat);
+
+            if (string.Equals(format, Consts.DateTimeFormatPrecisionSecondWithTimezoneOffset, StringComparison.Ordinal))
+            {
+                return Hl7DateTimeFormatConfig.FormatDateTimeUsingSourceOffset(dateTime);
+            }
+
             return dateTime.ToString(format, culture);
         }
 

--- a/test/ClearHl7.Tests/IntegrationTests/SegmentDateTimePrecisionIntegrationTests.cs
+++ b/test/ClearHl7.Tests/IntegrationTests/SegmentDateTimePrecisionIntegrationTests.cs
@@ -17,6 +17,7 @@ namespace ClearHl7.Tests.IntegrationTests
             // Ensure clean test state
             Hl7DateTimeFormatConfig.ClearFieldPrecisions();
             Hl7DateTimeFormatConfig.ClearGlobalOverride();
+            Hl7DateTimeFormatConfig.TimezoneOffset = TimeSpan.Zero;
         }
 
         public void Dispose()
@@ -24,6 +25,7 @@ namespace ClearHl7.Tests.IntegrationTests
             // Clean up after each test to prevent affecting other tests
             Hl7DateTimeFormatConfig.ClearFieldPrecisions();
             Hl7DateTimeFormatConfig.ClearGlobalOverride();
+            Hl7DateTimeFormatConfig.TimezoneOffset = TimeSpan.Zero;
         }
 
         [Fact]
@@ -123,6 +125,44 @@ namespace ClearHl7.Tests.IntegrationTests
             
             // Field 6 (EventOccurred) should be second precision (original)  
             Assert.Equal("20240315143045", fields[6]); // Second precision
+        }
+
+        [Fact]
+        public void MshSegment_WithTimezoneOffsetFieldOverride_UsesConfiguredPositiveOffset()
+        {
+            // Arrange
+            var dateTime = new DateTime(2024, 3, 15, 14, 30, 45);
+            var messageType = new MessageType { MessageCode = "ADT", TriggerEvent = "A01", MessageStructure = "ADT_A01" };
+            var processingType = new ProcessingType { ProcessingId = "P" };
+            Hl7DateTimeFormatConfig.TimezoneOffset = TimeSpan.FromHours(10);
+            Hl7DateTimeFormatConfig.SetPrecision<MshSegment>(x => x.DateTimeOfMessage, Consts.DateTimeFormatPrecisionSecondWithTimezoneOffset);
+
+            var segment = new MshSegment(dateTime, messageType, "MSG001", processingType);
+
+            // Act
+            string delimitedString = segment.ToDelimitedString();
+
+            // Assert
+            Assert.Contains("20240315143045+1000", delimitedString);
+        }
+
+        [Fact]
+        public void MshSegment_WithTimezoneOffsetFieldOverride_UsesConfiguredNegativeOffset()
+        {
+            // Arrange
+            var dateTime = new DateTime(2024, 3, 15, 14, 30, 45);
+            var messageType = new MessageType { MessageCode = "ADT", TriggerEvent = "A01", MessageStructure = "ADT_A01" };
+            var processingType = new ProcessingType { ProcessingId = "P" };
+            Hl7DateTimeFormatConfig.TimezoneOffset = TimeSpan.FromHours(-5);
+            Hl7DateTimeFormatConfig.SetPrecision<MshSegment>(x => x.DateTimeOfMessage, Consts.DateTimeFormatPrecisionSecondWithTimezoneOffset);
+
+            var segment = new MshSegment(dateTime, messageType, "MSG001", processingType);
+
+            // Act
+            string delimitedString = segment.ToDelimitedString();
+
+            // Assert
+            Assert.Contains("20240315143045-0500", delimitedString);
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes a bug where configuring a field with `Consts.DateTimeFormatPrecisionSecondWithTimezoneOffset` produced incorrect output such as:

- `20260421152153±1504`

instead of a valid HL7 timestamp with offset, for example:

- `20260421152153+1000`

## Problem
`Consts.DateTimeFormatPrecisionSecondWithTimezoneOffset` was being passed through the normal `DateTime.ToString(...)` path.

That constant is intended to represent an HL7-style timestamp with timezone offset:

- `yyyyMMddHHmmss±HHMM`

However, it is not a valid .NET offset format string. As a result:
- `±` was treated as a literal character
- `HH` was interpreted as hour
- `MM` was interpreted as month

This caused invalid serialized values like `±1504` instead of a real timezone offset.

## Fix
Special-case `Consts.DateTimeFormatPrecisionSecondWithTimezoneOffset` in the field-based DateTime serialization path and route it through the existing HL7 offset formatting helper logic.

This makes `SetPrecision<TSegment>(..., Consts.DateTimeFormatPrecisionSecondWithTimezoneOffset)` behave as expected and use the configured `Hl7DateTimeFormatConfig.TimezoneOffset`.

## Behavior after change
Configured fields now serialize correctly with HL7-compliant offsets, including both:
- positive offsets, e.g. `+1000`
- negative offsets, e.g. `-0500`

The fallback behavior remains consistent with the library’s existing default offset configuration.

## Tests
Added integration coverage to verify:
- configured timezone-offset precision produces `+1000`
- configured timezone-offset precision produces `-0500`

Also verified relevant timezone-offset/configuration tests pass.
